### PR TITLE
New $modelPing provider and service

### DIFF
--- a/src/ping.js
+++ b/src/ping.js
@@ -1,0 +1,64 @@
+!function () {
+    "use strict";
+
+    angular.module( "syonet.model" ).provider( "$modelPing", pingProvider );
+
+    function pingProvider () {
+        var provider = this;
+
+        /**
+         * Get/set the timeout (in ms) for pinging the target REST server
+         *
+         * @param   {Number}
+         */
+        provider.timeout = 5000;
+
+        /**
+         * Get/set the delay (in ms) for triggering another ping request.
+         *
+         * @param   {Number}
+         */
+        provider.pingDelay = 60000;
+
+        this.$get = function ( $http, $timeout, $modelPromise ) {
+            var cache = {};
+
+            /**
+             * Clear the ping request for a given URL.
+             * Uses $timeout, however does not trigger a digest cycle.
+             */
+            function clear ( url ) {
+                $timeout(function () {
+                    delete cache[ url ];
+                }, provider.pingDelay, false );
+            }
+
+            /**
+             * Create a ping request and return its promise.
+             * If the given URL has already been pinged in the last <code>pingDelay</code>
+             * milliseconds, then the existing promise will be returned.
+             *
+             * @param   {String} url
+             * @param   {Boolean} [force]
+             * @returns {Promise}
+             */
+            return function ( url, force ) {
+                if ( cache[ url ] && !force ) {
+                    return cache[ url ];
+                }
+
+                return cache[ url ] = $http({
+                    method: "HEAD",
+                    url: url,
+                    timeout: provider.timeout
+                }).then(function () {
+                    clear( url );
+                    return $modelPromise.reject( new Error( "Succesfully pinged RESTful server" ) );
+                }, function ( err ) {
+                    clear( url );
+                    return err;
+                });
+            };
+        };
+    }
+}();

--- a/src/request.js
+++ b/src/request.js
@@ -7,20 +7,6 @@
         var provider = this;
 
         /**
-         * Get/set the timeout (in ms) for pinging the target REST server
-         *
-         * @param   {Number}
-         */
-        provider.timeout = 5000;
-
-        /**
-         * Get/set the delay (in ms) for triggering another ping request.
-         *
-         * @param   {Number}
-         */
-        provider.pingDelay = 60000;
-
-        /**
          * The name of an alternative header that will contain the Content-Length, in case
          * the server provides it.
          * Useful when computing the length of a response which has Transfer-Encoding: chunked
@@ -35,9 +21,7 @@
          */
         provider.idFieldHeader = "X-Id-Field";
 
-        provider.$get = function ( $timeout, $http, $window, $modelPromise, $modelTemp ) {
-            var currPing;
-
+        provider.$get = function ( $http, $window, $modelPromise, $modelTemp, $modelPing ) {
             /**
              * Return a URL suitable for the ping request.
              * The returned value contains only the protocol and host, with no path.
@@ -47,38 +31,6 @@
              */
             function getPingUrl ( url ) {
                 return url.replace( /^(https?:\/\/)?(.*?)\/.+$/i, "$1$2/" );
-            }
-
-            /**
-             * Create a ping request and return its promise.
-             * If it's a
-             *
-             * @param   {String} url
-             * @param   {Boolean} [force]
-             * @returns {Promise}
-             */
-            function createPingRequest ( url, force ) {
-                return currPing = ( !force && currPing ) || $http({
-                    method: "HEAD",
-                    url: url,
-                    timeout: provider.timeout
-                }).then(function () {
-                    clearPingRequest();
-                    return $modelPromise.reject( new Error( "Succesfully pinged RESTful server" ) );
-                }, function ( err ) {
-                    clearPingRequest();
-                    return err;
-                });
-            }
-
-            /**
-             * Clear the current saved ping request.
-             * Uses $timeout, however does not trigger a digest cycle.
-             */
-            function clearPingRequest () {
-                $timeout(function () {
-                    currPing = null;
-                }, provider.pingDelay, false );
             }
 
             /**
@@ -170,7 +122,7 @@
                     params: safe ? data : null,
                     data: safe ? null : data,
                     headers: {},
-                    timeout: createPingRequest( pingUrl, options.force )
+                    timeout: $modelPing( pingUrl, options.force )
                 };
 
                 // FIXME This functionality has not been tested yet.

--- a/src/sync.js
+++ b/src/sync.js
@@ -3,7 +3,7 @@
 
     angular.module( "syonet.model" ).provider( "modelSync", modelSyncProvider );
 
-    function modelSyncProvider ( $modelRequestProvider ) {
+    function modelSyncProvider ( $modelPingProvider ) {
         var provider = this;
 
         provider.$get = function ( $interval, $document, $modelRequest, $modelDB, $modelPromise ) {
@@ -154,7 +154,7 @@
              *                           used is the ping delay.
              */
             sync.schedule = function ( delay ) {
-                delay = Math.max( delay || $modelRequestProvider.pingDelay );
+                delay = Math.max( delay || $modelPingProvider.pingDelay );
 
                 sync.schedule.cancel();
                 sync.$$schedule = $interval( sync, delay );

--- a/test/specs/model.spec.js
+++ b/test/specs/model.spec.js
@@ -59,6 +59,7 @@ describe( "model", function () {
         return promise.then(function () {
             return model.base( "/api" );
         }).then(function () {
+            $httpBackend.expectHEAD( "/api" ).respond( 200 );
             $httpBackend.expectGET( "/api/foo" ).respond( 0, null );
             promise = model( "foo" ).list();
             testHelpers.flush( true );

--- a/test/specs/ping.spec.js
+++ b/test/specs/ping.spec.js
@@ -72,4 +72,14 @@ describe( "$modelPing", function () {
         expect( $http ).to.have.callCount( 2 );
         testHelpers.flush();
     });
+
+    it( "should execute request before delay if URLs are different", function () {
+        $httpBackend.whenHEAD( "/foo" ).respond( 200 );
+
+        ping( "/" );
+        ping( "/foo" );
+
+        expect( $http ).to.have.callCount( 2 );
+        testHelpers.flush();
+    });
 });

--- a/test/specs/ping.spec.js
+++ b/test/specs/ping.spec.js
@@ -1,0 +1,75 @@
+describe( "$modelPing", function () {
+    "use strict";
+
+    var $http, $httpBackend, provider, ping;
+
+    beforeEach( module( "syonet.model", function ( $provide, $modelPingProvider ) {
+        provider = $modelPingProvider;
+        $provide.decorator( "$http", function ( $delegate ) {
+            return sinon.spy( $delegate );
+        });
+    }));
+
+    beforeEach( inject(function ( $injector ) {
+        // Initialize test helpers
+        testHelpers( $injector );
+
+        $http = $injector.get( "$http" );
+        $httpBackend = $injector.get( "$httpBackend" );
+        ping = $injector.get( "$modelPing" );
+    }));
+
+    afterEach(function () {
+        $httpBackend.verifyNoOutstandingExpectation( false );
+        $httpBackend.verifyNoOutstandingRequest( false );
+    });
+
+    it( "should reject when pinged", function () {
+        var promise = ping( "/" );
+        testHelpers.flush( true );
+
+        return expect( promise ).to.be.rejected;
+    });
+
+    it( "should resolve when not pinged", function () {
+        var promise = ping( "/" );
+
+        testHelpers.ping.respond( 0 );
+        testHelpers.flush( true );
+
+        return expect( promise ).to.be.fulfilled;
+    });
+
+    it( "should timeout", function () {
+        provider.timeout = 100;
+        ping( "/" );
+
+        testHelpers.flush();
+
+        expect( $http ).to.have.been.calledWithMatch({
+            method: "HEAD",
+            timeout: 100
+        });
+    });
+
+    it( "should not be retriggered before delay has passed", function () {
+        ping( "/" );
+        ping( "/" );
+
+        expect( $http ).to.have.callCount( 1 );
+        testHelpers.flush();
+        testHelpers.timeout();
+
+        ping( "/" );
+        expect( $http ).to.have.callCount( 2 );
+        testHelpers.flush();
+    });
+
+    it( "should be passed thru with force option", function () {
+        ping( "/" );
+        ping( "/", true );
+
+        expect( $http ).to.have.callCount( 2 );
+        testHelpers.flush();
+    });
+});

--- a/test/specs/request.spec.js
+++ b/test/specs/request.spec.js
@@ -165,40 +165,17 @@ describe( "$modelRequest", function () {
     // ---------------------------------------------------------------------------------------------
 
     describe( "pings", function () {
-        it( "should timeout requests", function ( done ) {
+        it( "should timeout requests", function () {
             var promise;
 
-            provider.timeout = 100;
             testHelpers.ping.respond( 0 );
             $httpBackend.expectGET( "/foo" ).respond( 200, {} );
             promise = req( "/foo", "GET" );
 
-            setTimeout(function () {
-                testHelpers.flush( true );
-
-                expect( promise ).to.eventually.be.rejectedWith( sinon.match({
-                    status: 0
-                })).then( done, done );
-            }, 100 );
-        });
-
-        it( "should not be retriggered before delay has passed", function () {
-            $http = $http.withArgs( sinon.match({
-                method: "HEAD"
+            testHelpers.flush( true );
+            return expect( promise ).to.eventually.be.rejectedWith( sinon.match({
+                status: 0
             }));
-
-            $httpBackend.whenGET( "/foo" ).respond( [] );
-
-            req( "/foo", "GET" );
-            req( "/foo", "GET" );
-
-            expect( $http ).to.have.callCount( 1 );
-            testHelpers.flush();
-            testHelpers.timeout();
-
-            req( "/foo", "GET" );
-            expect( $http ).to.have.callCount( 2 );
-            testHelpers.flush();
         });
 
         it( "should be sent to base URL if available", function () {
@@ -207,40 +184,6 @@ describe( "$modelRequest", function () {
 
             req( "/", "GET", null, {
                 baseUrl: "/api"
-            });
-
-            testHelpers.flush();
-        });
-
-        it( "should be passed thru with force option", function () {
-            $http = $http.withArgs( sinon.match({
-                method: "HEAD"
-            }));
-
-            $httpBackend.whenGET( "/foo" ).respond( [] );
-
-            req( "/foo", "GET" );
-            req( "/foo", "GET", null, {
-                force: true
-            });
-
-            expect( $http ).to.have.callCount( 2 );
-            testHelpers.flush();
-        });
-    });
-
-    // ---------------------------------------------------------------------------------------------
-
-    describe( ".timeout", function () {
-        it( "should define the timeout for pinging the server", function () {
-            provider.timeout = 123;
-
-            $httpBackend.expectGET( "/" ).respond( 200 );
-            req( "/", "GET" );
-
-            expect( $http ).to.have.been.calledWithMatch({
-                method: "HEAD",
-                timeout: 123
             });
 
             testHelpers.flush();

--- a/test/specs/sync.spec.js
+++ b/test/specs/sync.spec.js
@@ -1,10 +1,10 @@
 describe( "modelSync", function () {
     "use strict";
 
-    var $q, $httpBackend, $interval, $modelDB, db, sync, model, reqProvider, req;
+    var $q, $httpBackend, $interval, $modelDB, db, sync, model, pingProvider, req;
 
-    beforeEach( module( "syonet.model", function ( $modelRequestProvider, $provide ) {
-        reqProvider = $modelRequestProvider;
+    beforeEach( module( "syonet.model", function ( $modelPingProvider, $provide ) {
+        pingProvider = $modelPingProvider;
 
         $provide.decorator( "$modelRequest", function ( $delegate, $q ) {
             req = sinon.stub().returns( $q.when( true ) );
@@ -207,7 +207,7 @@ describe( "modelSync", function () {
     describe( ".schedule( delay )", function () {
         it( "should use ping delay as the minimum delay between calls", function () {
             sync.schedule( 30 );
-            expect( $interval ).to.have.been.calledWith( sync, reqProvider.pingDelay );
+            expect( $interval ).to.have.been.calledWith( sync, pingProvider.pingDelay );
         });
 
         it( "should cancel the other schedule", function () {


### PR DESCRIPTION
The new provider/service is just an extraction from the same feature existing inside `$modelRequest`.
Every test related to this change has been moved to the new spec as well.