### PR TITLE
ID Fields in constructor

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -134,6 +134,7 @@
 
                 if ( name instanceof Model ) {
                     id = name._path.id;
+                    options = options || name._options;
                     name = name._path.name;
                 }
 

--- a/src/model.js
+++ b/src/model.js
@@ -45,12 +45,16 @@
 
             /**
              * @param   {String} name
+             * @param   {Object} [options]
+             * @param   {String|String[]} [options.id="id"]  List of fields to take from the XHR
+             *                                               response and adopt as the primary key
+             *                                               of the returned array/object.
              * @returns {Model}
              * @constructor
              */
-            function Model ( name ) {
+            function Model ( name, options ) {
                 if ( !( this instanceof Model ) ) {
-                    return new Model( name );
+                    return new Model( name, options );
                 }
 
                 if ( !name ) {
@@ -61,6 +65,7 @@
                     return $modelDB( name );
                 });
 
+                this._options = options;
                 this._path = {
                     name: name
                 };
@@ -77,7 +82,7 @@
                 var model = this;
                 var url = model.toURL();
 
-                options = angular.extend( {}, options, {
+                options = angular.extend( {}, options, model._options, {
                     auth: provider.auth(),
                     baseUrl: Model.base()
                 });
@@ -110,7 +115,7 @@
                     return this._path.id;
                 }
 
-                other = new Model( this._path.name );
+                other = new Model( this._path.name, this._options );
                 other._parent = this._parent;
                 other._path.id = id;
 
@@ -121,9 +126,10 @@
              * Creates a new model with the specified `name` inheriting from this one.
              *
              * @param   {String} name
+             * @param   {Object} [options]  Model options. See {@link Model} for further info.
              * @returns {Model}
              */
-            Model.prototype.model = function ( name ) {
+            Model.prototype.model = function ( name, options ) {
                 var other, id;
 
                 if ( name instanceof Model ) {
@@ -131,7 +137,7 @@
                     name = name._path.name;
                 }
 
-                other = new Model( name );
+                other = new Model( name, options );
                 other._parent = this;
                 other._path.id = id;
 

--- a/src/request.js
+++ b/src/request.js
@@ -15,12 +15,6 @@
          */
         provider.altContentLengthHeader = "X-Content-Length";
 
-        /**
-         * The name of the header that contains the ID fields in the response body.
-         * @type    {String}
-         */
-        provider.idFieldHeader = "X-Id-Field";
-
         provider.$get = function ( $http, $window, $modelPromise, $modelTemp, $modelPing ) {
             /**
              * Return a URL suitable for the ping request.
@@ -132,7 +126,7 @@
                 return updateTempRefs( config ).then(function ( config ) {
                     return $http( config ).then(function ( response ) {
                         var promise;
-                        response = applyIdField( response );
+                        response = applyIdField( response, options.id );
                         promise = $modelPromise.when( response );
 
                         // Set an persisted ID to the temporary ID posted
@@ -224,16 +218,16 @@
          * Applies the ID field into a HTTP response.
          *
          * @param   {Object} response
+         * @param   {String|String[]} [idFields]
          * @returns {Object|Object[]}
          */
-        function applyIdField ( response ) {
-            var idFields = response.headers( provider.idFieldHeader ) || "id";
+        function applyIdField ( response, idFields ) {
             var data = response.data;
             var isArray = angular.isArray( data );
+
+            idFields = idFields || "id";
+            idFields = angular.isArray( idFields ) ? idFields : [ idFields ];
             data = isArray ? data : [ data ];
-            idFields = idFields.split( "," ).map(function ( field ) {
-                return field.trim();
-            });
 
             data.forEach(function ( item ) {
                 var id = [];

--- a/test/specs/model.spec.js
+++ b/test/specs/model.spec.js
@@ -4,8 +4,12 @@ describe( "model", function () {
     var injector, $rootScope, $httpBackend, $modelDB, provider, model;
     var expect = chai.expect;
 
-    beforeEach( module( "syonet.model", function ( modelProvider ) {
+    beforeEach( module( "syonet.model", function ( $provide, modelProvider ) {
         provider = modelProvider;
+
+        $provide.decorator( "$modelRequest", function ( $delegate ) {
+            return sinon.spy( $delegate );
+        });
     }));
 
     beforeEach( inject(function ( $injector ) {
@@ -997,6 +1001,29 @@ describe( "model", function () {
                     promise = foo.db.get( "bar" );
                     return expect( promise ).to.be.rejected;
                 });
+            });
+        });
+    });
+
+    // ---------------------------------------------------------------------------------------------
+
+    describe( "._request()", function () {
+        var req;
+        beforeEach( inject( function ( $modelRequest ) {
+            req = $modelRequest;
+        }));
+
+        it( "should pass instance options to $modelRequest", function () {
+            var foo = model( "foo", {
+                bar: "baz"
+            });
+
+            $httpBackend.expectGET( "/foo" ).respond({});
+            foo.list();
+            testHelpers.flush();
+
+            expect( req ).to.have.been.calledWithMatch( "/foo", "GET", undefined, {
+                bar: "baz"
             });
         });
     });

--- a/test/specs/model.spec.js
+++ b/test/specs/model.spec.js
@@ -184,6 +184,18 @@ describe( "model", function () {
 
             expect( foo.model( bar ).toURL() ).to.eql( "/foo/123/bar/456" );
         });
+
+        it( "should pass new options", function () {
+            var opts = {};
+            var foo = model( "foo", {
+                bar: "baz"
+            });
+            var bar = model( "bar", opts );
+
+            expect( foo.model( "bar" ) ).to.not.have.property( "_options" );
+            expect( foo.model( "bar", opts ) ).to.have.property( "_options", opts );
+            expect( foo.model( bar ) ).to.have.property( "_options", opts );
+        });
     });
 
     // ---------------------------------------------------------------------------------------------

--- a/test/specs/request.spec.js
+++ b/test/specs/request.spec.js
@@ -206,4 +206,22 @@ describe( "$modelRequest", function () {
         });
     });
 
+    // ---------------------------------------------------------------------------------------------
+
+    describe( "option id", function () {
+        it( "should be used to determine the ID fields in the response body", function () {
+            var promise;
+            $httpBackend.expectGET( "/foo/bar" ).respond( 200, {
+                baz: "qux"
+            });
+
+            promise = req( "/foo/bar", "GET", null, {
+                id: "baz"
+            });
+
+            expect( promise ).to.eventually.have.property( "_id", "qux" );
+            testHelpers.flush();
+        });
+    });
+
 });

--- a/test/specs/request.spec.js
+++ b/test/specs/request.spec.js
@@ -206,24 +206,4 @@ describe( "$modelRequest", function () {
         });
     });
 
-    // ---------------------------------------------------------------------------------------------
-
-    describe( ".idFieldHeader", function () {
-        it( "should be used to determine the ID fields in the response headers", function () {
-            var promise;
-
-            provider.idFieldHeader = "X-Id";
-
-            $httpBackend.expectGET( "/foo/bar" ).respond( 200, {
-                baz: "qux"
-            }, {
-                "X-Id": "baz"
-            });
-            promise = req( "/foo/bar", "GET" );
-            expect( promise ).to.eventually.have.property( "_id", "qux" );
-
-            testHelpers.flush();
-        });
-    });
-
 });


### PR DESCRIPTION
Instead of requesting the API to send the ID fields via a header, the ID fields will now be passed in the `model` constructor.

Closes #25 

_THIS IS A BREAKING CHANGE._