### PR TITLE
Update angular-pouchdb to v3.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,14 +2,11 @@
     "name": "syonet.model",
     "main": "dist/syonet.model.js",
     "dependencies": {
-        "angular": "~1.3.0",
-        "angular-pouchdb": "~1.0.2"
+        "angular": "~1.4.4",
+        "angular-pouchdb": "~3.0.0"
     },
     "devDependencies": {
-        "angular-mocks": "~1.3.0"
-    },
-    "resolutions": {
-        "angular": "~1.3.0"
+        "angular-mocks": "~1.4.4"
     },
     "ignore": [
         "src",

--- a/src/pouchdb-plugins.js
+++ b/src/pouchdb-plugins.js
@@ -3,13 +3,15 @@
 
     angular.module( "syonet.model" ).config( createPluginMethods );
 
-    function createPluginMethods ( pouchDBProvider ) {
+    function createPluginMethods ( pouchDBProvider, POUCHDB_METHODS ) {
         var plugins = {
             patch: patch
         };
 
         PouchDB.plugin( plugins );
-        // pouchDBProvider.methods = POUCHDB_DEFAULT_METHODS.concat( Object.keys( plugins ) );
+        pouchDBProvider.methods = angular.extend( {}, POUCHDB_METHODS, {
+            patch: "qify"
+        });
 
         // -----------------------------------------------------------------------------------------
 

--- a/src/pouchdb-plugins.js
+++ b/src/pouchdb-plugins.js
@@ -3,13 +3,13 @@
 
     angular.module( "syonet.model" ).config( createPluginMethods );
 
-    function createPluginMethods ( pouchDBProvider, POUCHDB_DEFAULT_METHODS ) {
+    function createPluginMethods ( pouchDBProvider ) {
         var plugins = {
             patch: patch
         };
 
         PouchDB.plugin( plugins );
-        pouchDBProvider.methods = POUCHDB_DEFAULT_METHODS.concat( Object.keys( plugins ) );
+        // pouchDBProvider.methods = POUCHDB_DEFAULT_METHODS.concat( Object.keys( plugins ) );
 
         // -----------------------------------------------------------------------------------------
 

--- a/test/init.js
+++ b/test/init.js
@@ -11,10 +11,12 @@ if ( !proto.bind ) {
     };
 }
 
-function testHelpers ( $injector ) {
+function testHelpers () {}
+angular.module( "syonet.model" ).run(function ( $injector ) {
     var $timeout = $injector.get( "$timeout" );
     var $httpBackend = $injector.get( "$httpBackend" );
     var $rootScope = $injector.get( "$rootScope" );
+    var $window = $injector.get( "$window" );
 
     // Ping request backend definition
     testHelpers.ping = $httpBackend.whenHEAD( "/" ).respond( 200 );
@@ -30,4 +32,9 @@ function testHelpers ( $injector ) {
     testHelpers.flush = function ( timeout ) {
         timeout ? setTimeout( $httpBackend.flush ) : $httpBackend.flush();
     };
-}
+
+    testHelpers.asyncDigest = function () {
+        var interval = $window.setInterval( $rootScope.$digest.bind( $rootScope ) );
+        return $window.clearInterval.bind( null, interval );
+    };
+});

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -5,8 +5,6 @@ module.exports = function ( config ) {
         basePath: "..",
         frameworks: [ "mocha", "chai", "chai-as-promised", "sinon-chai" ],
         files: [
-            "test/init.js",
-
             // Production deps
             "libs/pouchdb/dist/pouchdb.js",
             "libs/angular/angular.js",
@@ -18,6 +16,9 @@ module.exports = function ( config ) {
             // Sources
             "src/module.js",
             "src/**/*.js",
+
+            // Test initialization code
+            "test/init.js",
 
             // Test specs
             "test/specs/**/*.js"

--- a/test/specs/cache.spec.js
+++ b/test/specs/cache.spec.js
@@ -1,26 +1,30 @@
-describe( "$modelCache", function () {
+describe.only( "$modelCache", function () {
     "use strict";
 
-    var db, model, cache;
+    var db, model, cache, $rootScope, $window;
     beforeEach( module( "syonet.model" ) );
     beforeEach( inject(function ( $injector ) {
         model = $injector.get( "model" );
         cache = $injector.get( "$modelCache" );
         db = $injector.get( "$modelDB" );
+
+        $rootScope = $injector.get( "$rootScope" );
+        $window = $injector.get( "$window" );
     }));
 
     afterEach(function () {
-        return db.clear();
+        return db.clear().finally( testHelpers.asyncDigest() );
     });
 
     describe( ".set()", function () {
         it( "should create documents when they don't exist", function () {
             var foo = model( "foo" );
+
             return cache.set( foo, {
                 _id: "foo"
             }).then(function () {
                 return expect( foo.db.get( "foo" ) ).to.be.fulfilled;
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
 
         it( "should update existing documents", function () {
@@ -34,7 +38,7 @@ describe( "$modelCache", function () {
                 return cache.set( foo, data );
             }).then(function () {
                 return expect( foo.db.get( "foo" ) ).to.eventually.have.property( "bar", "baz" );
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
 
         it( "should do bulk operations", function () {
@@ -47,7 +51,7 @@ describe( "$modelCache", function () {
                 return expect( foo.db.get( "foo" ) ).to.be.fulfilled;
             }).then(function () {
                 return expect( foo.db.get( "bar" ) ).to.be.fulfilled;
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
 
         it( "should return the updated documents", function () {
@@ -57,10 +61,9 @@ describe( "$modelCache", function () {
                 foo: "bar"
             }];
 
-            return expect( cache.set( foo, data ) ).to.eventually.have.deep.property(
-                "[0].foo",
-                "bar"
-            );
+            return cache.set( foo, data ).then(function ( docs ) {
+                expect( docs ).to.have.deep.property( "[0].foo", "bar" );
+            }).finally( testHelpers.asyncDigest() );
         });
 
         it( "should store parents", function () {
@@ -74,7 +77,7 @@ describe( "$modelCache", function () {
                         $parents: {}
                     }
                 });
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
     });
 
@@ -97,7 +100,7 @@ describe( "$modelCache", function () {
             }).then(function ( doc ) {
                 expect( doc ).to.have.property( "bar", "barbaz" );
                 expect( doc ).to.have.property( "baz", true );
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
 
         it( "should create documents when they don't exist", function () {
@@ -106,7 +109,7 @@ describe( "$modelCache", function () {
                 _id: "foo"
             }).then(function () {
                 return expect( foo.db.get( "foo" ) ).to.be.fulfilled;
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
 
         it( "should return extended data", function () {
@@ -123,7 +126,7 @@ describe( "$modelCache", function () {
                     "bar",
                     "barbaz"
                 );
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
     });
 
@@ -143,7 +146,7 @@ describe( "$modelCache", function () {
             }).then(function () {
                 // 1 item is the management data, never removed
                 return expect( foo.db.allDocs() ).to.eventually.have.property( "total_rows", 2 );
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
 
         it( "should remove all documents from DB if no data passed", function () {
@@ -155,7 +158,7 @@ describe( "$modelCache", function () {
             }).then(function () {
                 // 1 item is the management data, never removed
                 return expect( foo.db.allDocs() ).to.eventually.have.property( "total_rows", 1 );
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
     });
 
@@ -169,7 +172,7 @@ describe( "$modelCache", function () {
                 foo: "bar"
             }).then( function () {
                 return expect( cache.getOne( foobar ) ).to.eventually.have.property( "foo", "bar" );
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
 
         it( "should return cached document with same parents", function () {
@@ -184,7 +187,7 @@ describe( "$modelCache", function () {
                         $parents: {}
                     }
                 });
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
 
         it( "should reject whwen no document with same parents exist", function () {
@@ -194,7 +197,7 @@ describe( "$modelCache", function () {
                 _id: "qux"
             }).then(function () {
                 return expect( cache.getOne( m2 ) ).to.be.rejected;
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
     });
 
@@ -215,7 +218,7 @@ describe( "$modelCache", function () {
                 _id: "baz"
             }]).then(function () {
                 return expect( cache.getAll( foo ) ).to.eventually.have.length( 2 );
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
 
         it( "should not return protected documents", function () {
@@ -226,7 +229,7 @@ describe( "$modelCache", function () {
 
             return cache.compact( foo ).then(function () {
                 return expect( cache.getAll( foo ) ).to.eventually.have.length( 0 );
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
 
         it( "should return cached documents with same parents", function () {
@@ -243,7 +246,7 @@ describe( "$modelCache", function () {
             }).then(function () {
                 var promise = cache.getAll( baz );
                 return expect( promise ).to.eventually.have.length( 2 );
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
 
         it( "should return proper 'touched' value for different parents", function () {
@@ -253,7 +256,7 @@ describe( "$modelCache", function () {
             }]).then(function () {
                 var promise = cache.getAll( model( "baz" ) );
                 return expect( promise ).to.eventually.have.property( "touched", false );
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
     });
 
@@ -278,7 +281,7 @@ describe( "$modelCache", function () {
                 return cache.compact( foo );
             }).then(function () {
                 expect( spy ).to.have.been.calledOnce;
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
 
         it( "should compact each 1000 updates to the DB", function () {
@@ -291,7 +294,7 @@ describe( "$modelCache", function () {
 
             return cache.compact( foo ).then(function () {
                 expect( spy ).to.not.have.been.called;
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
     });
 });

--- a/test/specs/cache.spec.js
+++ b/test/specs/cache.spec.js
@@ -1,4 +1,4 @@
-describe.only( "$modelCache", function () {
+describe( "$modelCache", function () {
     "use strict";
 
     var db, model, cache, $rootScope, $window;

--- a/test/specs/db.spec.js
+++ b/test/specs/db.spec.js
@@ -35,7 +35,7 @@ describe( "$modelDB", function () {
                 expect( spy ).to.be.calledWith( "modelDB.foo" );
                 expect( spy ).to.be.calledWith( "modelDB.bar" );
                 expect( spy ).to.be.calledWith( "modelDB.__updates" );
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
     });
 
@@ -46,7 +46,7 @@ describe( "$modelDB", function () {
             var promise;
 
             provider.dbNamePrefix = "model";
-            promise = model( "foo" ).db.info();
+            promise = model( "foo" ).db.info().finally( testHelpers.asyncDigest() );
 
             return expect( promise ).to.eventually.have.property( "db_name", "model.foo" );
         });

--- a/test/specs/model.spec.js
+++ b/test/specs/model.spec.js
@@ -529,6 +529,10 @@ describe( "model service", function () {
             it( "should reject if no cache is available", function () {
                 var promise;
 
+                inject(function ( $modelCache, $q ) {
+                    sinon.stub( $modelCache, "getOne" ).returns( $q.defer().promise );
+                });
+
                 $httpBackend.expectGET( "/foo/bar" ).respond( 0, null );
                 promise = model( "foo" ).id( "bar" ).get().finally( testHelpers.asyncDigest() );
 

--- a/test/specs/model.spec.js
+++ b/test/specs/model.spec.js
@@ -30,8 +30,6 @@ describe( "model", function () {
     }));
 
     beforeEach( inject(function ( $injector ) {
-        testHelpers( $injector );
-
         injector = $injector;
         $rootScope = $injector.get( "$rootScope" );
         $httpBackend = $injector.get( "$httpBackend" );

--- a/test/specs/ping.spec.js
+++ b/test/specs/ping.spec.js
@@ -11,9 +11,6 @@ describe( "$modelPing", function () {
     }));
 
     beforeEach( inject(function ( $injector ) {
-        // Initialize test helpers
-        testHelpers( $injector );
-
         $http = $injector.get( "$http" );
         $httpBackend = $injector.get( "$httpBackend" );
         ping = $injector.get( "$modelPing" );

--- a/test/specs/pouchdb-plugins.spec.js
+++ b/test/specs/pouchdb-plugins.spec.js
@@ -5,7 +5,6 @@ describe( "PouchDB plugins", function () {
 
     beforeEach( module( "syonet.model" ) );
     beforeEach( inject(function ( $injector, _pouchDB_ ) {
-        testHelpers( $injector );
         db = _pouchDB_( "foo" );
     }));
 

--- a/test/specs/pouchdb-plugins.spec.js
+++ b/test/specs/pouchdb-plugins.spec.js
@@ -9,7 +9,7 @@ describe( "PouchDB plugins", function () {
     }));
 
     afterEach(function () {
-        return db.destroy();
+        return db.destroy().finally( testHelpers.asyncDigest() );
     });
 
     describe( ".patch()", function () {
@@ -22,11 +22,12 @@ describe( "PouchDB plugins", function () {
                 }, "foobar" );
             }).then(function () {
                 return expect( db.get( "foobar" ) ).to.eventually.have.property( "foo", "barbaz" );
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
 
         it( "should reject if document doesn't exist", function () {
-            return expect( db.patch( {}, "xyz" ) ).to.be.rejected;
+            var promise = db.patch( {}, "xyz" ).finally( testHelpers.asyncDigest() );
+            return expect( promise ).to.be.rejected;
         });
     });
 });

--- a/test/specs/request.spec.js
+++ b/test/specs/request.spec.js
@@ -24,7 +24,7 @@ describe( "$modelRequest", function () {
         $httpBackend.verifyNoOutstandingRequest( false );
 
         localStorage.clear();
-        return $modelDB.clear();
+        return $modelDB.clear().finally( testHelpers.asyncDigest() );
     });
 
     it( "should return successful HTTP response", function () {
@@ -116,7 +116,7 @@ describe( "$modelRequest", function () {
             });
 
             return promise;
-        });
+        }).finally( testHelpers.asyncDigest() );
     });
 
     it( "should replace temporary IDs in URL", function () {
@@ -144,13 +144,13 @@ describe( "$modelRequest", function () {
             });
 
             return promise;
-        });
+        }).finally( testHelpers.asyncDigest() );
     });
 
     it( "should allow bypassing the HTTP request", function () {
         var promise = req( "/foo", "GET", null, {
             bypass: true
-        });
+        }).finally( testHelpers.asyncDigest() );
 
         testHelpers.digest( true );
         return expect( promise ).to.be.rejectedWith({

--- a/test/specs/request.spec.js
+++ b/test/specs/request.spec.js
@@ -12,9 +12,6 @@ describe( "$modelRequest", function () {
     }));
 
     beforeEach( inject(function ( $injector ) {
-        // Initialize test helpers
-        testHelpers( $injector );
-
         $http = $injector.get( "$http" );
         $httpBackend = $injector.get( "$httpBackend" );
         $modelTemp = $injector.get( "$modelTemp" );

--- a/test/specs/sync.spec.js
+++ b/test/specs/sync.spec.js
@@ -28,7 +28,7 @@ describe( "modelSync", function () {
 
     afterEach(function () {
         localStorage.clear();
-        return $modelDB.clear();
+        return $modelDB.clear().finally( testHelpers.asyncDigest() );
     });
 
     it( "should have an event emitter interface", function () {
@@ -48,7 +48,7 @@ describe( "modelSync", function () {
             expect( req ).to.have.been.calledWith( "/", "POST" );
             expect( req ).to.have.been.calledWith( "/foo", "PATCH" );
             expect( spy ).to.have.been.calledWith( "success" );
-        });
+        }).finally( testHelpers.asyncDigest() );
     });
 
     it( "should retrigger with provided options", function () {
@@ -62,7 +62,7 @@ describe( "modelSync", function () {
         testHelpers.digest( true );
         return sync.store( "/", "POST", null, options ).then( sync ).then(function () {
             expect( req ).to.have.been.calledWith( "/", "POST", null, options );
-        });
+        }).finally( testHelpers.asyncDigest() );
     });
 
     it( "should trigger error event with the promise rejection cause", function () {
@@ -78,7 +78,7 @@ describe( "modelSync", function () {
         testHelpers.digest( true );
         return $q.all( stores ).then( sync ).catch( sinon.spy() ).then(function () {
             expect( spy ).to.have.been.calledWith( "error", "foo" );
-        });
+        }).finally( testHelpers.asyncDigest() );
     });
 
     it( "should not allow two synchronizations to overlap", function () {
@@ -90,7 +90,7 @@ describe( "modelSync", function () {
         var spy = sinon.spy( sync, "emit" );
         return sync().then(function () {
             expect( spy ).to.not.have.been.called;
-        });
+        }).finally( testHelpers.asyncDigest() );
     });
 
     it( "should have a default scheduled synchronization interval", function () {
@@ -113,7 +113,7 @@ describe( "modelSync", function () {
             return sync.store( "/foo", "PATCH" );
         }).then( sync ).catch( sinon.spy() ).then(function () {
             return expect( db.allDocs() ).to.eventually.have.property( "total_rows", 1 );
-        });
+        }).finally( testHelpers.asyncDigest() );
     });
 
     it( "should execute requests in series", function () {
@@ -127,7 +127,7 @@ describe( "modelSync", function () {
             var req2 = req.withArgs( "/foo", "DELETE" );
 
             expect( req1 ).to.have.been.calledBefore( req2 );
-        });
+        }).finally( testHelpers.asyncDigest() );
     });
 
     // ---------------------------------------------------------------------------------------------
@@ -171,7 +171,7 @@ describe( "modelSync", function () {
             }).then(function ( docs ) {
                 expect( docs.rows ).to.have.deep.property( "[0].doc.foo", "bar" );
                 expect( docs.rows ).to.have.deep.property( "[1].doc.foo", "barbaz" );
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
 
         it( "should remove items with no previous version", function () {
@@ -196,7 +196,7 @@ describe( "modelSync", function () {
 
                 // 1 item is the management data, never removed
                 return expect( promise ).to.eventually.have.property( "total_rows", 1 );
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
     });
 
@@ -241,7 +241,7 @@ describe( "modelSync", function () {
 
                 expect( doc.model ).to.equal( "/" );
                 expect( doc.method ).to.equal( "GET" );
-            });
+            }).finally( testHelpers.asyncDigest() );
         });
     });
 });

--- a/test/specs/sync.spec.js
+++ b/test/specs/sync.spec.js
@@ -18,8 +18,6 @@ describe( "modelSync", function () {
     }));
 
     beforeEach( inject(function ( $injector ) {
-        testHelpers( $injector );
-
         $q = $injector.get( "$modelPromise" );
         $httpBackend = $injector.get( "$httpBackend" );
         $modelDB = $injector.get( "$modelDB" );


### PR DESCRIPTION
Updated `angular-pouchdb` to v3.0.0.

This implies in updating tests because of a bug (?) in ngMocks, as reported [here](http://stackoverflow.com/questions/32051825/external-promises-never-finish-in-unit-tests-with-ngmock) and in angular-pouchdb/angular-pouchdb#57.